### PR TITLE
Enable RPC

### DIFF
--- a/packages/react-api/src/Api.tsx
+++ b/packages/react-api/src/Api.tsx
@@ -17,10 +17,11 @@ import { createType } from '@polkadot/types';
 import { formatBalance, isTestChain } from '@polkadot/util';
 import { setSS58Format } from '@polkadot/util-crypto';
 import addressDefaults from '@polkadot/util-crypto/address/defaults';
+import CENNZRuntimeTypes from '@cennznet/types/injects';
 
 import ApiContext from './ApiContext';
 import registry from './typeRegistry';
-import CENNZRuntimeTypes from '@cennznet/types/injects';
+import cennznetRpc from './cennznetRpcDecoration';
 
 interface Props {
   children: React.ReactNode;
@@ -126,7 +127,13 @@ export default function Api ({ children, url }: Props): React.ReactElement<Props
     const provider = new WsProvider(url);
     const signer = new ApiSigner(queuePayload, queueSetTxStatus);
 
-    api = new ApiPromise({ provider, registry, signer, types: { ...CENNZRuntimeTypes as any } });
+    api = new ApiPromise({
+      provider,
+      registry,
+      rpc: cennznetRpc,
+      signer,
+      types: { ...(CENNZRuntimeTypes as any) }
+    });
 
     api.on('connected', (): void => setIsApiConnected(true));
     api.on('disconnected', (): void => setIsApiConnected(false));

--- a/packages/react-api/src/cennznetRpcDecoration.ts
+++ b/packages/react-api/src/cennznetRpcDecoration.ts
@@ -1,0 +1,26 @@
+const cennzx = [
+  {
+    name: 'buyPrice',
+    description: 'Retrieves the spot exchange buy price',
+    params: [
+      { name: 'AssetToBuy', type: 'AssetId' },
+      { name: 'Amount', type: 'Balance' },
+      { name: 'AssetToPay', type: 'AssetId' }
+    ],
+    type: 'Balance'
+  },
+  {
+    name: 'sellPrice',
+    description: 'Retrieves the spot exchange sell price',
+    params: [
+      { name: 'AssetToSell', type: 'AssetId' },
+      { name: 'Amount', type: 'Balance' },
+      { name: 'AssetToPayout', type: 'AssetId' }
+    ],
+    type: 'Balance'
+  }
+];
+
+export default {
+  cennzx
+};

--- a/packages/react-components/src/InputRpc/SelectMethod.tsx
+++ b/packages/react-components/src/InputRpc/SelectMethod.tsx
@@ -8,7 +8,7 @@ import { BareProps } from '../types';
 
 import React from 'react';
 
-import map from '@polkadot/jsonrpc';
+import cennznetJsonRpc from './cennznetJsonRpc';
 
 import Dropdown from '../Dropdown';
 import { classes } from '../util';
@@ -22,7 +22,7 @@ interface Props extends BareProps {
 
 function transform ({ value }: Props): (method: string) => RpcMethod {
   return function (method: string): RpcMethod {
-    return map[value.section].methods[method];
+    return cennznetJsonRpc[value.section].methods[method];
   };
 }
 

--- a/packages/react-components/src/InputRpc/cennznetJsonRpc.ts
+++ b/packages/react-components/src/InputRpc/cennznetJsonRpc.ts
@@ -1,0 +1,45 @@
+/**
+ * @polkadot/jsonrpc has been deprecated since version 1.8.1
+ *
+ * TODO: Get refactored by using types to make PRC decoration, once polkadot/api dependency is upgraded to 1.8.1 above
+ */
+import defaultJsonRpc from '@polkadot/jsonrpc';
+import createMethod from '@polkadot/jsonrpc/create/method';
+import createParam from '@polkadot/jsonrpc/create/param';
+import { RpcMethodOpt } from '@polkadot/jsonrpc/types';
+
+const buyPrice: RpcMethodOpt = {
+  description: 'Retrieves the spot exchange buy price',
+  params: [
+    createParam('AssetToBuy', 'AssetId'),
+    createParam('Amount', 'Balance'),
+    createParam('AssetToPay', 'AssetId')
+  ],
+  type: 'Balance'
+};
+
+const sellPrice: RpcMethodOpt = {
+  description: 'Retrieves the spot exchange sell price',
+  params: [
+    createParam('AssetToSell', 'AssetId'),
+    createParam('Amount', 'Balance'),
+    createParam('AssetToPayout', 'AssetId')
+  ],
+  type: 'Balance'
+};
+
+const cennznetJsonRpc = Object.assign({}, defaultJsonRpc, {
+  cennzx: {
+    isDeprecated: false,
+    isHidden: false,
+    description:
+      'CENNZX-spot',
+    section: 'cennzx',
+    methods: {
+      buyPrice: createMethod('cennzx', 'buyPrice', buyPrice),
+      sellPrice: createMethod('cennzx', 'sellPrice', sellPrice)
+    }
+  }
+});
+
+export default cennznetJsonRpc;

--- a/packages/react-components/src/InputRpc/index.tsx
+++ b/packages/react-components/src/InputRpc/index.tsx
@@ -8,7 +8,6 @@ import { RpcMethod } from '@polkadot/jsonrpc/types';
 import { DropdownOptions } from '../util/types';
 
 import React, { useState } from 'react';
-import map from '@polkadot/jsonrpc';
 import { useApi } from '@polkadot/react-hooks';
 
 import LinkedWrapper from '../InputExtrinsic/LinkedWrapper';
@@ -16,6 +15,7 @@ import SelectMethod from './SelectMethod';
 import SelectSection from './SelectSection';
 import methodOptions from './options/method';
 import sectionOptions from './options/section';
+import cennznetJsonRpc from './cennznetJsonRpc';
 
 interface Props {
   className?: string;
@@ -51,7 +51,7 @@ export default function InputRpc ({ className, defaultValue, help, label, onChan
     const optionsMethod = methodOptions(api, section);
 
     setOptionsMethod(optionsMethod);
-    _onMethodChange(map[section].methods[optionsMethod[0].value]);
+    _onMethodChange(cennznetJsonRpc[section].methods[optionsMethod[0].value]);
   };
 
   return (

--- a/packages/react-components/src/InputRpc/options/method.tsx
+++ b/packages/react-components/src/InputRpc/options/method.tsx
@@ -6,10 +6,10 @@ import { DropdownOption, DropdownOptions } from '../../util/types';
 
 import React from 'react';
 import ApiPromise from '@polkadot/api/promise';
-import map from '@polkadot/jsonrpc';
+import cennznetJsonRpc from '../cennznetJsonRpc';
 
 export default function createOptions (api: ApiPromise, sectionName: string): DropdownOptions {
-  const section = map[sectionName];
+  const section = cennznetJsonRpc[sectionName];
 
   if (!section || Object.keys((api.rpc as any)[sectionName]).length === 0) {
     return [];


### PR DESCRIPTION
CENNX RPC interfaces are available in ui (would suggest to deal with any potential CENNZX related issues in a separated ticket).

Note:

- `@polkadot/jsonrpc` is removed from npm, new approach on decorating RPC is available from `polkadot@1.8.1`, and we may need to refactor the code in the PR after we upgrading to latest polkadot dependencies; https://github.com/polkadot-js/api/pull/2064/files

<img width="875" alt="Screen Shot 2020-04-15 at 3 35 14 PM" src="https://user-images.githubusercontent.com/1513326/79296175-c9422580-7f2e-11ea-9d1f-c2361261f7cd.png">
