### PR TITLE
Fix restore account page error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,7 +11,7 @@ module.exports = {
   },
   rules: {
     ...base.rules,
-    '@typescript-eslint/no-explicit-any': 'off',
-    '@typescript-eslint/ban-ts-ignore': 'off'
+    '@typescript-eslint/ban-ts-ignore': 'off',
+    '@typescript-eslint/no-explicit-any': 'off'
   }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
   },
   rules: {
     ...base.rules,
-    '@typescript-eslint/no-explicit-any': 'off'
+    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/ban-ts-ignore': 'off'
   }
 };

--- a/packages/react-components/src/CryptoType.tsx
+++ b/packages/react-components/src/CryptoType.tsx
@@ -25,6 +25,9 @@ export default function CryptoType ({ accountId, className, label = '' }: Props)
         : null;
 
       if (current) {
+        // @ts-ignore
+        const currentType = typeof current.type === 'object' && current.type.type ? current.type.type : current.type;
+
         setType(
           current.meta.isInjected
             ? 'injected'
@@ -32,7 +35,7 @@ export default function CryptoType ({ accountId, className, label = '' }: Props)
               ? current.meta.hardwareType || 'hardware'
               : current.meta.isExternal
                 ? 'external'
-                : current.type
+                : currentType
         );
       }
     } catch (error) {

--- a/packages/react-components/src/CryptoType.tsx
+++ b/packages/react-components/src/CryptoType.tsx
@@ -25,9 +25,6 @@ export default function CryptoType ({ accountId, className, label = '' }: Props)
         : null;
 
       if (current) {
-        // @ts-ignore
-        const currentType = typeof current.type === 'object' && current.type.type ? current.type.type : current.type;
-
         setType(
           current.meta.isInjected
             ? 'injected'
@@ -35,7 +32,8 @@ export default function CryptoType ({ accountId, className, label = '' }: Props)
               ? current.meta.hardwareType || 'hardware'
               : current.meta.isExternal
                 ? 'external'
-                : currentType
+                // @ts-ignore
+                : current?.type?.type || current?.type || 'unknown'
         );
       }
     } catch (error) {


### PR DESCRIPTION
Account info would be stored in browser localStorage, and the data structure is a bit different after restoring compared with creating account:

It supposes to be `{"encoding": {"content": ["sr25519"]}}` stored in localStorage (when create accounts),  but got `{"encoding": {"content": [{type: "sr25519"}]}}` when restore accounts.

![Kapture 2020-05-26 at 16 21 50](https://user-images.githubusercontent.com/1513326/82860281-33f27200-9f6d-11ea-9faa-52ea6b4662fd.gif)
