### PR TITLE
Added changes required to support RPC call

### DIFF
--- a/packages/react-components/src/InputRpc/CennznetJsonRpc.ts
+++ b/packages/react-components/src/InputRpc/CennznetJsonRpc.ts
@@ -1,19 +1,20 @@
 import defaultJsonRpc from '@polkadot/jsonrpc';
 import createMethod from '@polkadot/jsonrpc/create/method';
 import createParam from '@polkadot/jsonrpc/create/param';
-import  userBare  from '@cennznet/api/rpc';
+import  cennznetBare  from '@cennznet/api/rpc';
 
-const userRpc = Object.entries(userBare).reduce((user, [sectionName, methods]) => {
+const userRpc = Object.entries(cennznetBare).reduce((user, [sectionName, methods]) => {
     // @ts-ignore
-    user[sectionName] =  { methods: methods.reduce((section, def) => {
+    user[sectionName] =  {
+        // @ts-ignore
+        methods: methods.reduce((section, def) => {
         const {
             description = 'User defined',
             name,
             params,
             type
         } = def;
-
-            section[name] = createMethod(sectionName, name, {
+        section[name] = createMethod(sectionName, name, {
             description,
             params: params.map(({
                                     // @ts-ignore
@@ -22,19 +23,17 @@ const userRpc = Object.entries(userBare).reduce((user, [sectionName, methods]) =
                                     name,
                                     // @ts-ignore
                                     type
-                                }) => createParam(name, type, {
+            }) => createParam(name, type, {
                 isOptional
             })),
             type: type
         });
         return section;
-    }, {})
+        }, {})
     }
     return user;
-}, {}); // decorate the sections with base and user methods
+    }, {}); // decorate the sections with base and user methods
 
-const cennznetJsonRpc = Object.assign({}, defaultJsonRpc,
-    userRpc
-);
+const cennznetJsonRpc = Object.assign({}, defaultJsonRpc, userRpc);
 
 export default cennznetJsonRpc;

--- a/packages/react-components/src/InputRpc/CennznetJsonRpc.ts
+++ b/packages/react-components/src/InputRpc/CennznetJsonRpc.ts
@@ -1,7 +1,7 @@
 import defaultJsonRpc from '@polkadot/jsonrpc';
 import createMethod from '@polkadot/jsonrpc/create/method';
 import createParam from '@polkadot/jsonrpc/create/param';
-import  cennznetBare  from '@cennznet/api/rpc';
+import cennznetBare from '@cennznet/api/rpc';
 
 const userRpc = Object.entries(cennznetBare).reduce((user, [sectionName, methods]) => {
     // @ts-ignore

--- a/packages/react-components/src/InputRpc/CennznetJsonRpc.ts
+++ b/packages/react-components/src/InputRpc/CennznetJsonRpc.ts
@@ -1,0 +1,40 @@
+import defaultJsonRpc from '@polkadot/jsonrpc';
+import createMethod from '@polkadot/jsonrpc/create/method';
+import createParam from '@polkadot/jsonrpc/create/param';
+import  userBare  from '@cennznet/api/rpc';
+
+const userRpc = Object.entries(userBare).reduce((user, [sectionName, methods]) => {
+    // @ts-ignore
+    user[sectionName] =  { methods: methods.reduce((section, def) => {
+        const {
+            description = 'User defined',
+            name,
+            params,
+            type
+        } = def;
+
+            section[name] = createMethod(sectionName, name, {
+            description,
+            params: params.map(({
+                                    // @ts-ignore
+                                    isOptional,
+                                    // @ts-ignore
+                                    name,
+                                    // @ts-ignore
+                                    type
+                                }) => createParam(name, type, {
+                isOptional
+            })),
+            type: type
+        });
+        return section;
+    }, {})
+    }
+    return user;
+}, {}); // decorate the sections with base and user methods
+
+const cennznetJsonRpc = Object.assign({}, defaultJsonRpc,
+    userRpc
+);
+
+export default cennznetJsonRpc;

--- a/packages/react-components/src/InputRpc/CennznetJsonRpc.ts
+++ b/packages/react-components/src/InputRpc/CennznetJsonRpc.ts
@@ -4,35 +4,35 @@ import createParam from '@polkadot/jsonrpc/create/param';
 import cennznetBare from '@cennznet/api/rpc';
 
 const userRpc = Object.entries(cennznetBare).reduce((user, [sectionName, methods]) => {
+  // @ts-ignore
+  user[sectionName] = {
     // @ts-ignore
-    user[sectionName] =  {
-        // @ts-ignore
-        methods: methods.reduce((section, def) => {
-        const {
-            description = 'User defined',
-            name,
-            params,
-            type
-        } = def;
-        section[name] = createMethod(sectionName, name, {
-            description,
-            params: params.map(({
-                                    // @ts-ignore
-                                    isOptional,
-                                    // @ts-ignore
-                                    name,
-                                    // @ts-ignore
-                                    type
-            }) => createParam(name, type, {
-                isOptional
-            })),
-            type: type
-        });
-        return section;
-        }, {})
-    }
-    return user;
-    }, {}); // decorate the sections with base and user methods
+    methods: methods.reduce((section, def) => {
+      const {
+        description = 'User defined',
+        name,
+        params,
+        type
+      } = def;
+      section[name] = createMethod(sectionName, name, {
+        description,
+        params: params.map(({
+                              // @ts-ignore
+                              isOptional,
+                              // @ts-ignore
+                              name,
+                              // @ts-ignore
+                              type
+                            }) => createParam(name, type, {
+          isOptional
+        })),
+        type: type
+      });
+      return section;
+    }, {})
+  }
+  return user;
+}, {}); // decorate the sections with base and user methods
 
 const cennznetJsonRpc = Object.assign({}, defaultJsonRpc, userRpc);
 

--- a/packages/react-components/src/InputRpc/SelectMethod.tsx
+++ b/packages/react-components/src/InputRpc/SelectMethod.tsx
@@ -8,7 +8,7 @@ import { BareProps } from '../types';
 
 import React from 'react';
 
-import map from './cennznetJsonRpc';
+import map from './CennznetJsonRpc';
 
 import Dropdown from '../Dropdown';
 import { classes } from '../util';

--- a/packages/react-components/src/InputRpc/SelectMethod.tsx
+++ b/packages/react-components/src/InputRpc/SelectMethod.tsx
@@ -8,7 +8,7 @@ import { BareProps } from '../types';
 
 import React from 'react';
 
-import map from '@polkadot/jsonrpc';
+import map from './cennznetJsonRpc';
 
 import Dropdown from '../Dropdown';
 import { classes } from '../util';

--- a/packages/react-components/src/InputRpc/index.tsx
+++ b/packages/react-components/src/InputRpc/index.tsx
@@ -8,7 +8,7 @@ import { RpcMethod } from '@polkadot/jsonrpc/types';
 import { DropdownOptions } from '../util/types';
 
 import React, { useState } from 'react';
-import map from './cennznetJsonRpc';
+import map from './CennznetJsonRpc';
 import { useApi } from '@polkadot/react-hooks';
 
 import LinkedWrapper from '../InputExtrinsic/LinkedWrapper';

--- a/packages/react-components/src/InputRpc/index.tsx
+++ b/packages/react-components/src/InputRpc/index.tsx
@@ -8,7 +8,7 @@ import { RpcMethod } from '@polkadot/jsonrpc/types';
 import { DropdownOptions } from '../util/types';
 
 import React, { useState } from 'react';
-import map from '@polkadot/jsonrpc';
+import map from './cennznetJsonRpc';
 import { useApi } from '@polkadot/react-hooks';
 
 import LinkedWrapper from '../InputExtrinsic/LinkedWrapper';

--- a/packages/react-components/src/InputRpc/options/method.tsx
+++ b/packages/react-components/src/InputRpc/options/method.tsx
@@ -25,7 +25,7 @@ export default function createOptions (api: ApiPromise, sectionName: string): Dr
     })
     .map((value): DropdownOption => {
       const { description, params } = section.methods[value];
-      const inputs = params.map(({ name }): string => name).join(', ');
+      const inputs = params.map(({ name }: { name : string }): string => name).join(', ');
 
       return {
         className: 'ui--DropdownLinked-Item',

--- a/packages/react-components/src/InputRpc/options/method.tsx
+++ b/packages/react-components/src/InputRpc/options/method.tsx
@@ -6,7 +6,7 @@ import { DropdownOption, DropdownOptions } from '../../util/types';
 
 import React from 'react';
 import ApiPromise from '@polkadot/api/promise';
-import map from '@polkadot/jsonrpc';
+import map from '../cennznetJsonRpc';
 
 export default function createOptions (api: ApiPromise, sectionName: string): DropdownOptions {
   const section = map[sectionName];

--- a/packages/react-components/src/InputRpc/options/method.tsx
+++ b/packages/react-components/src/InputRpc/options/method.tsx
@@ -6,7 +6,7 @@ import { DropdownOption, DropdownOptions } from '../../util/types';
 
 import React from 'react';
 import ApiPromise from '@polkadot/api/promise';
-import map from '../cennznetJsonRpc';
+import map from '../CennznetJsonRpc';
 
 export default function createOptions (api: ApiPromise, sectionName: string): DropdownOptions {
   const section = map[sectionName];


### PR DESCRIPTION
While working on this task - Enable CENNZnet specific RPC calls in the UI where we discussed to create a API release exposing the RPC call.. Figured out we already have the package @cennznet/api/rpc exposed, so could avoid the step for releasing patch version of API.. Have made some functional changes, with which we no longer would need to make ongoing changes when we add new rpc calls (it will be taken care)..

To test Cennzx calls, added liquidity for CENNZ asset (16000) and tried to check sell/buy price in UI.. the following gif shows that..  

![rpc calls](https://user-images.githubusercontent.com/29415595/86546739-6474f500-bf8a-11ea-8572-fed83ef33212.gif)
