### PR TITLE
Fix balance in fees section

### DIFF
--- a/packages/react-components/src/InputBalance.tsx
+++ b/packages/react-components/src/InputBalance.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { BitLengthOption } from '@polkadot/react-components/constants';
 import { InputNumber } from '@polkadot/react-components';
-import { formatBalance } from '@polkadot/util';
+import { getFormatedBalance } from "@polkadot/react-components/util";
 
 interface Props extends BareProps {
   autoFocus?: boolean;
@@ -35,8 +35,9 @@ interface Props extends BareProps {
 const DEFAULT_BITLENGTH = BitLengthOption.CHAIN_SPEC as BitLength;
 
 function InputBalance ({ autoFocus, className, defaultValue: inDefault, help, isDisabled, isError, isFull, isZeroable, label, labelExtra, maxValue, onChange, onEnter, onEscape, placeholder, style, value, withEllipsis, withLabel, withMax }: Props): React.ReactElement<Props> {
+  let balance = getFormatedBalance(inDefault, false);
   const defaultValue = inDefault
-    ? formatBalance(inDefault, { forceUnit: '-', withSi: false }).replace(',', isDisabled ? ',' : '')
+    ? balance.replace(',', isDisabled ? ',' : '')
     : inDefault;
 
   return (

--- a/packages/react-components/src/util/getFormatedBalance.ts
+++ b/packages/react-components/src/util/getFormatedBalance.ts
@@ -1,0 +1,21 @@
+import { formatBalance, formatDecimal } from '@polkadot/util';
+
+// Get formatted balance function takes the 'big number' value and break
+// the values in prefix and postfix .. The postfix is then displayed as (default = 4) 4 decimal place value
+// if postfix is 432 -> 0432
+export default function getFormattedBalance(value: any, supportsUnit?: boolean) {
+  if (value) {
+    const default_balance_param = formatBalance.getDefaults();
+    const DECIMAL_PLACES = default_balance_param.decimals;
+    const UNIT = default_balance_param.unit;
+    const text = value.toString();
+    const mid = text.length - DECIMAL_PLACES;
+    const prefix = formatDecimal(text.substr(0, mid) || '0');
+    const padding = mid < 0 ? 0 - mid : 0;
+    const zeros = '0';
+    const postfix = "".concat("".concat(new Array(padding + 1).join('0')).concat(text).substr(mid < 0 ? 0 : mid), zeros.repeat(DECIMAL_PLACES)).substr(0, DECIMAL_PLACES);
+    return supportsUnit ? `${prefix}.${postfix} ${UNIT}` : `${prefix}.${postfix}`;
+  } else {
+    return '';
+  }
+}

--- a/packages/react-components/src/util/index.ts
+++ b/packages/react-components/src/util/index.ts
@@ -10,3 +10,4 @@ export { default as getContractAbi } from './getContractAbi';
 export { default as isTreasuryProposalVote } from './isTreasuryProposalVote';
 export { default as toAddress } from './toAddress';
 export { default as toShortAddress } from './toShortAddress';
+export { default as getFormatedBalance } from './getFormatedBalance';

--- a/packages/react-components/test/getFormatedBalance.spec.ts
+++ b/packages/react-components/test/getFormatedBalance.spec.ts
@@ -1,0 +1,79 @@
+import BN from 'bn.js';
+import getFormattedBalance from '../src/util/getFormatedBalance';
+import { formatBalance } from '@polkadot/util';
+
+describe('get formattedBalance with decimals as per set in formatBalances default setting', () => {
+  formatBalance.setDefaults({
+    decimals: 4,
+    unit: 'CPAY'
+  });
+  const TESTVAL = new BN('123456789000');
+  const TESTVAL2 = new BN('99878888865439');
+  const TESTVAL3 = new BN('123');
+  it('formats 123,456,789,000 (decimals=4)', () => {
+    const showUnit = false;
+    expect(getFormattedBalance(TESTVAL, showUnit)).toEqual('12,345,678.9000');
+  });
+  it('formats 123,456,789,000 (decimals=4, with unit CPAY)', () => {
+    const showUnit = true;
+    expect(getFormattedBalance(TESTVAL, showUnit)).toEqual('12,345,678.9000 CPAY');
+  });
+  it('formats 99878888865439 (decimals=4, with unit CPAY)', () => {
+    const showUnit = true;
+    expect(getFormattedBalance(TESTVAL2, showUnit)).toEqual('9,987,888,886.5439 CPAY');
+  });
+  it('formats 99878888865439 (decimals=6, with unit CENNZ)', () => {
+    const showUnit = true;
+    formatBalance.setDefaults({
+      decimals: 6,
+      unit: 'CENNZ'
+    });
+    expect(getFormattedBalance(TESTVAL2, showUnit)).toEqual('99,878,888.865439 CENNZ');
+  });
+  describe('test cases when values <= the decimal places', () =>
+  {
+    it('formats 123 (decimals=5, with unit XYZ)', () => {
+      const showUnit = true;
+      formatBalance.setDefaults({
+        decimals: 5,
+        unit: 'XYZ'
+      });
+      expect(getFormattedBalance(TESTVAL3, showUnit)).toEqual('0.00123 XYZ');
+    });
+    it('formats 123 (decimals=3, with unit XYZ)', () => {
+      const showUnit = true;
+      formatBalance.setDefaults({
+        decimals: 3,
+        unit: 'XYZ'
+      });
+      expect(getFormattedBalance(TESTVAL3, showUnit)).toEqual('0.123 XYZ');
+    });
+    it('formats 1 (decimals=2, with no unit)', () => {
+      const value = new BN(1);
+      const showUnit = false;
+      formatBalance.setDefaults({
+        decimals: 2,
+        unit: 'XYZ'
+      });
+      expect(getFormattedBalance(value, showUnit)).toEqual('0.01');
+    });
+    it('formats 12 (decimals=4, with no unit)', () => {
+      const value = new BN(12);
+      const showUnit = false;
+      formatBalance.setDefaults({
+        decimals: 4,
+        unit: 'XYZ'
+      });
+      expect(getFormattedBalance(value, showUnit)).toEqual('0.0012');
+    });
+    it('formats 1234 (decimals=4, with no unit)', () => {
+      const value = new BN(1234);
+      const showUnit = false;
+      formatBalance.setDefaults({
+        decimals: 4,
+        unit: 'XYZ'
+      });
+      expect(getFormattedBalance(value, showUnit)).toEqual('0.1234');
+    });
+  });
+});

--- a/packages/react-signer/src/Checks/index.tsx
+++ b/packages/react-signer/src/Checks/index.tsx
@@ -15,7 +15,7 @@ import { Compact, UInt } from '@polkadot/types';
 import { Icon } from '@polkadot/react-components';
 import { useApi } from '@polkadot/react-hooks';
 import { compactToU8a, formatBalance } from '@polkadot/util';
-
+import { getFormatedBalance } from "@polkadot/react-components/util";
 import { useTranslation } from '../translate';
 import ContractCall from './ContractCall';
 import ContractDeploy from './ContractDeploy';
@@ -278,6 +278,8 @@ export default function Checks ({ accountId, className, extrinsic }: Props): Rea
     return null;
   }
 
+  const fees = getFormatedBalance(dispatchInfo.partialFee, true);
+
   return (
     <article
       className={[className, 'ui--Checks', 'normal', 'padded'].join(' ')}
@@ -287,7 +289,7 @@ export default function Checks ({ accountId, className, extrinsic }: Props): Rea
         <Icon name='arrow right' />
         {t('Fees of {{fees}} will be applied to the submission', {
           replace: {
-            fees: formatBalance(dispatchInfo.partialFee, { withSiFull: true })
+            fees
           }
         })}
       </div>


### PR DESCRIPTION
Have fixed the fees balance on extrinsic page..
Will need to search more places for balance and fix it..
Have changed the form of output for rpc calls from toHuman to toString as toHuman will internally call formatBalance with unit and withSi.
Will discuss with the team on the output..
<img width="1108" alt="Screen Shot 2020-07-16 at 3 06 07 PM" src="https://user-images.githubusercontent.com/29415595/87621875-f09acf80-c775-11ea-9cb7-f853a7c4182b.png">
