### PR TITLE
Refactor formatBalance input as big number

### DIFF
--- a/packages/react-components/src/util/index.ts
+++ b/packages/react-components/src/util/index.ts
@@ -11,3 +11,4 @@ export { default as isTreasuryProposalVote } from './isTreasuryProposalVote';
 export { default as toAddress } from './toAddress';
 export { default as toShortAddress } from './toShortAddress';
 export { default as getFormatedBalance } from './getFormatedBalance';
+export { default as toFormattedBalance } from './toFormattedBalance';

--- a/packages/react-components/src/util/toFormattedBalance.ts
+++ b/packages/react-components/src/util/toFormattedBalance.ts
@@ -1,7 +1,8 @@
+import BN from 'bn.js';
 import { formatBalance } from '@polkadot/util';
 
 interface Arguments {
-  balance: string;
+  balance: BN | string;
   fixedPoint?: number;
   unit?: string;
 }
@@ -24,20 +25,17 @@ const toFormattedBalance = (args: Arguments): string => {
     fixedPoint = DEFAULT_FIXED_POINT,
     unit = DEFAULT_UNIT
   } = args;
-  const balanceAsNumber = parseInt(balance, 10);
   const unitPart = unit ? ` ${unit}` : '';
-
-  if (!balance || isNaN(balanceAsNumber)) {
-    throw new Error(`Balance value is not valid: ${balance}`);
-  }
 
   /**
    * Condition 1: balance length is smaller than fixed point, e.g:
    * "123" ==> "0.1230" # when value length (3) is smaller than fixed point (4)
    */
-  if (balance.length <= fixedPoint) {
+  if (balance.toString().length <= fixedPoint) {
+    const valueAsBN = BN.isBN(balance) ? balance : new BN(balance);
     const scalingSize = Math.pow(10, 1 - fixedPoint);
-    const valuePart = (balanceAsNumber * scalingSize).toFixed(fixedPoint);
+    const valuePart = (valueAsBN.toNumber() * scalingSize).toFixed(fixedPoint);
+
 
     return `${valuePart}${unitPart}`;
   }
@@ -53,9 +51,8 @@ const toFormattedBalance = (args: Arguments): string => {
   };
   const formattedBalance = formatBalance(balance, polkadotFormatBalanceOptions);
 
-  console.log('object', polkadotFormatBalanceOptions);
   const integerPart = formattedBalance.split('.')[0];
-  const decimalPart = balance.slice(-fixedPoint);
+  const decimalPart = balance.toString().slice(-fixedPoint);
 
   return `${integerPart}.${decimalPart}${unitPart}`;
 };

--- a/packages/react-components/test/toFormattedBalance.spec.ts
+++ b/packages/react-components/test/toFormattedBalance.spec.ts
@@ -1,23 +1,34 @@
+import BN from 'bn.js';
 import toFormattedBalance from '../src/util/toFormattedBalance';
 
 describe('toFormattedBalance', () => {
   describe('with default settings', () => {
     test('when value length is smaller than default fixed point(4)', () => {
-      const stubBalanceValue = '123';
+      const stubBalanceValue = new BN('123');
       const result = toFormattedBalance({ balance: stubBalanceValue });
       expect(result).toEqual('0.1230');
     });
 
     test('when value length is larger than default fixed point(4)', () => {
-      const stubBalanceValue = '123456789';
+      const stubBalanceValue = new BN('123456789');
       const result = toFormattedBalance({ balance: stubBalanceValue });
       expect(result).toEqual('12,345.6789');
+    });
+
+    test('when value is a big number', () => {
+      const stubBalanceValue = new BN(
+        '123456789012345678901234567890123456789012345678901234567890'
+      );
+      const result = toFormattedBalance({ balance: stubBalanceValue });
+      expect(result).toEqual(
+        '12,345,678,901,234,567,890,123,456,789,012,345,678,901,234,567,890,123,456.7890'
+      );
     });
   });
 
   describe('with assigned fixed point', () => {
     test('when balance value length is smaller than assigned fixed point(2)', () => {
-      const stubBalanceValue = '123';
+      const stubBalanceValue = new BN('123');
       const result = toFormattedBalance({
         balance: stubBalanceValue,
         fixedPoint: 2
@@ -26,7 +37,7 @@ describe('toFormattedBalance', () => {
     });
 
     test('when balance value length is larger than assigned fixed point(2)', () => {
-      const stubBalanceValue = '123456789';
+      const stubBalanceValue = new BN('123456789');
       const result = toFormattedBalance({
         balance: stubBalanceValue,
         fixedPoint: 2
@@ -37,7 +48,7 @@ describe('toFormattedBalance', () => {
 
   describe('with assigned balance unit', () => {
     test('when balance unit is set with a small balance value', () => {
-      const stubBalanceValue = '0';
+      const stubBalanceValue = new BN('0');
       const result = toFormattedBalance({
         balance: stubBalanceValue,
         unit: 'CPAY'
@@ -46,7 +57,7 @@ describe('toFormattedBalance', () => {
     });
 
     test('when balance unit is set with a large balance value', () => {
-      const stubBalanceValue = '123456789';
+      const stubBalanceValue = new BN('123456789');
       const result = toFormattedBalance({
         balance: stubBalanceValue,
         unit: 'CENNZ'

--- a/packages/react-params/src/valueToText.tsx
+++ b/packages/react-params/src/valueToText.tsx
@@ -2,10 +2,10 @@
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
 
-import { Keys, ValidatorId } from '@polkadot/types/interfaces';
-
 import React from 'react';
-import { classes } from '@polkadot/react-components/util';
+import BN from 'bn.js';
+import { Keys, ValidatorId } from '@polkadot/types/interfaces';
+import { classes, toFormattedBalance } from '@polkadot/react-components/util';
 import { isNull, isUndefined, u8aToHex } from '@polkadot/util';
 import { Option, Raw } from '@polkadot/types';
 
@@ -37,6 +37,10 @@ function formatKeys (keys: [ValidatorId, Keys][]): string {
 export default function valueToText (type: string, value: any, swallowError = true, contentShorten = true): React.ReactNode {
   if (isNull(value) || isUndefined(value)) {
     return div({}, '<unknown>');
+  }
+
+  if (type === 'Balance') {
+    return toFormattedBalance({ balance: new BN(value.toString()) });
   }
 
   return div(


### PR DESCRIPTION
**This PR is aimed to be merged into feature branch `implement-balance-format`, including:**
- Refactored `toFormattedBalance` util to accept big number;
- Trial implementing `toFormattedBalance` in `storage` page only for now, will implement to other pages once this PR is ok;

**UI changes:**

Before:
<img width="601" alt="Screen Shot 2020-08-12 at 5 01 02 PM" src="https://user-images.githubusercontent.com/1513326/89977986-96335700-dcc0-11ea-8351-ca5e9f581449.png">


After:
<img width="599" alt="Screen Shot 2020-08-12 at 5 02 39 PM" src="https://user-images.githubusercontent.com/1513326/89978001-9fbcbf00-dcc0-11ea-8d98-158f5e5119b6.png">



**Tasks to complete [Fix balance components](https://centralitydev.atlassian.net/jira/software/projects/IND/boards/142?selectedIssue=IND-219)**:
- [x] Add `balance formatting` util; https://github.com/cennznet/ui/pull/60 ;
- **Implement `balance formatting` in `Storage` page as a trial;** https://github.com/cennznet/ui/pull/61
- [ ] Ensure `balance formatting` in most used pages;