### PR TITLE
Remove total issuance from explorer view

### DIFF
--- a/packages/app-explorer/src/Summary.tsx
+++ b/packages/app-explorer/src/Summary.tsx
@@ -6,7 +6,7 @@ import { I18nProps as Props } from '@polkadot/react-components/types';
 
 import React from 'react';
 import { SummaryBox, CardSummary } from '@polkadot/react-components';
-import { BestFinalized, BestNumber, TimeNow, TimePeriod, TotalIssuance } from '@polkadot/react-query';
+import { BestFinalized, BestNumber, TimeNow, TimePeriod } from '@polkadot/react-query';
 
 import SummarySession from './SummarySession';
 import translate from './translate';
@@ -23,12 +23,6 @@ function Summary ({ t }: Props): React.ReactElement<Props> {
           label={t('target')}
         >
           <TimePeriod />
-        </CardSummary>
-        <CardSummary
-          className='ui--media-small'
-          label={t('total issuance')}
-        >
-          <TotalIssuance />
         </CardSummary>
       </section>
       <section className='ui--media-large'>


### PR DESCRIPTION
It's not relevant
<img width="382" alt="Screen Shot 2020-09-21 at 1 37 39 PM" src="https://user-images.githubusercontent.com/5133901/93727527-a28bc780-fc0f-11ea-8ae9-d529f1b0ff78.png">
