### PR TITLE
support rpc call

### DIFF
--- a/packages/apps-routing/src/index.ts
+++ b/packages/apps-routing/src/index.ts
@@ -18,6 +18,7 @@ import settings from './settings';
 import society from './society';
 import storage from './storage';
 import sudo from './sudo';
+import toolbox from './toolbox';
 import transfer from './transfer';
 import landing from './landing';
 
@@ -50,6 +51,7 @@ const routes: Routes = appSettings.uiMode === 'light'
     sudo,
     null,
     settings,
+    toolbox,
     js,
     template
   );

--- a/packages/react-components/src/InputRpc/CennznetJsonRpc.ts
+++ b/packages/react-components/src/InputRpc/CennznetJsonRpc.ts
@@ -1,0 +1,27 @@
+import jsonrpc from '@polkadot/types/interfaces/jsonrpc';
+import {DefinitionRpcSub, DefinitionRpcParam, DefinitionTypeType} from '@cennznet/types';
+import {DefinitionRpcExt} from '@polkadot/types/types';
+import cennznetBare from '@cennznet/api/rpc';
+
+let cennznetRpc:{[index: string]:any} = cennznetBare;
+const newJsonrpc: Record<string, Record<string, DefinitionRpcExt>> = {};
+Object
+    .keys(cennznetRpc)
+    .forEach((section): void => {
+        newJsonrpc[section] = {};
+
+        Object.entries(cennznetRpc[section])
+            .forEach(([method, def]): void => {
+                const isSubscription = !!(def as DefinitionRpcSub).pubsub;
+                newJsonrpc[section][method] = ({
+                    ...def as {description: string,params: DefinitionRpcParam[],type: DefinitionTypeType} ,
+                    isSubscription,
+                    jsonrpc: `${section}_${method}`,
+                    method,
+                    section
+                });
+            });
+    });
+const cennznetJsonRpc = Object.assign({}, jsonrpc, newJsonrpc);
+
+export default cennznetJsonRpc;

--- a/packages/react-components/src/InputRpc/SelectMethod.tsx
+++ b/packages/react-components/src/InputRpc/SelectMethod.tsx
@@ -8,7 +8,7 @@ import { BareProps } from '../types';
 
 import React from 'react';
 
-import jsonrpc from '@polkadot/types/interfaces/jsonrpc';
+import jsonrpc from './CennznetJsonRpc';
 
 import Dropdown from '../Dropdown';
 import { classes } from '../util';

--- a/packages/react-components/src/InputRpc/index.tsx
+++ b/packages/react-components/src/InputRpc/index.tsx
@@ -8,8 +8,7 @@ import { DropdownOptions } from '../util/types';
 
 import React, { useCallback, useEffect, useState } from 'react';
 import { useApi } from '@polkadot/react-hooks';
-import jsonrpc from '@polkadot/types/interfaces/jsonrpc';
-
+import jsonrpc from './CennznetJsonRpc';
 import LinkedWrapper from '../InputExtrinsic/LinkedWrapper';
 import SelectMethod from './SelectMethod';
 import SelectSection from './SelectSection';

--- a/packages/react-components/src/InputRpc/options/method.tsx
+++ b/packages/react-components/src/InputRpc/options/method.tsx
@@ -6,7 +6,7 @@ import { DropdownOption, DropdownOptions } from '../../util/types';
 
 import React from 'react';
 import ApiPromise from '@polkadot/api/promise';
-import jsonrpc from '@polkadot/types/interfaces/jsonrpc';
+import jsonrpc from '../CennznetJsonRpc';
 
 export default function createOptions (api: ApiPromise, sectionName: string): DropdownOptions {
   const section = jsonrpc[sectionName];


### PR DESCRIPTION
Added liquidity in the pool for CENNZ-CPAY.. RPC calls works fine..
I also think we might be able to support the rpc call by changing - https://github.com/cennznet/api-types/blob/master/src/interfaces/cennzx/definitions.ts and https://github.com/cennznet/api-types/blob/master/src/interfaces/ga/definitions.ts
and then we might be able to remove the code at https://github.com/cennznet/api.js/tree/develop/packages/api/src/rpc.
Will do a little research on this soon.
![rpc](https://user-images.githubusercontent.com/29415595/97827580-96744900-1d29-11eb-8cc0-60e931c14e32.gif)
