### PR TITLE
Chore/new stake page

### DIFF
--- a/packages/app-accounts/src/modals/AccountsForStaking.tsx
+++ b/packages/app-accounts/src/modals/AccountsForStaking.tsx
@@ -1,0 +1,60 @@
+// Copyright 2017-2020 @polkadot/app-accounts authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+import styled from 'styled-components';
+import React from 'react';
+import { Modal } from '@polkadot/react-components';
+import { useTranslation } from '../translate';
+import { Link } from "react-router-dom";
+import { colors } from '../../../../styled-theming';
+
+interface Props {
+  className?: string;
+}
+
+const ModalHeader = styled.div`
+  font-size: 1.5em;
+  font-weight: bold;
+`;
+
+const Paragraph = styled.div`
+  line-height: 1.5rem;
+  font-weight: normal;
+`;
+
+const Modaldiv = styled.div`
+  padding: 0px 0px 60px 0px;
+  a {
+    float:left;
+    clear: left;
+    height: 20px;
+    font-weight: normal;
+  }
+`;
+
+function AccountCheckingModal ({className }: Props): React.ReactElement {
+  const { t } = useTranslation();
+
+  return (
+    <Modal className={className}>
+      <Modal.Content className='content'>
+        <ModalHeader>{t('No accounts available')}</ModalHeader>
+        <Paragraph>{t('You do not have any accounts for a new nomination, try:')}</Paragraph>
+        <Modaldiv className='info'>
+          <Link to={`/accounts`}>{'Create a new account'}</Link>
+          <Link to={`/staking/manage`}>{'Manage existing stake'}</Link>
+        </Modaldiv>
+      </Modal.Content>
+    </Modal>
+  );
+}
+export default styled(AccountCheckingModal)`
+background: ${colors.lightBrown} !important;
+border: solid 2px #d09c4e !important;
+.content {
+  margin-left: 2rem;
+  color: rgb(95 50 3 / 87%);
+  line-height: 2.5rem;
+  font-size: 1.2rem !important;
+}
+`;

--- a/packages/app-staking/src/Actions/index.tsx
+++ b/packages/app-staking/src/Actions/index.tsx
@@ -101,11 +101,11 @@ export default function Actions ({ className, isVisible }: Props): React.ReactEl
     const { t } = useTranslation();
     const transferrable = <span className='label'>{t('transferrable')}</span>;
     const notEnoughTransferrable = <span style={{ color: "#9f3a38" }}>{t('not enough to stake')}</span>;
-    const _openHelp = (): void => setOpenHelpDailog(true);
+    const _toggleHelp = (): void => setOpenHelpDailog(!openHelpDailog);
     const _closeHelp = (): void => setOpenHelpDailog(false);
     return (
           <div>
-            <HelpOverlay md={basicMd} initialVisibility={openHelpDailog} closeHelp={_closeHelp}/>
+            <HelpOverlay md={basicMd} openHelpDailog={openHelpDailog} closeHelp={_closeHelp}/>
             <div className={`${className} ${!isVisible && 'staking--hidden'}`} style={{fontSize:'24px', color:'black'}}>
               Stake <b>CENNZ</b> and nominate the best validators to earn <b>Cpay</b> rewards
             </div>
@@ -113,7 +113,7 @@ export default function Actions ({ className, isVisible }: Props): React.ReactEl
                   style={{marginTop:'1%', backgroundColor: '#f19135'}}
                   label={t('Know the risks')}
                   icon='exclamation'
-                  onClick={_openHelp}
+                  onClick={_toggleHelp}
                   isPrimary
             />
             <div className='extrinsics--Selection' style={{marginTop:'2%', width:'50%', borderRadius: '35px', padding: '20px', border: '2px solid #D0D0D0', background:'white'}}>

--- a/packages/app-staking/src/Actions/index.tsx
+++ b/packages/app-staking/src/Actions/index.tsx
@@ -3,17 +3,183 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 
-import React from 'react';
+import React, {useEffect, useMemo, useState} from 'react';
 import {BareProps} from "@polkadot/react-components/types";
+import {
+    InputAddress,
+    Table,
+    AddressSmall,
+    Button,
+    Icon,
+    InputBalance,
+    TxButton
+} from "@polkadot/react-components";
+import {useTranslation} from "@polkadot/app-staking/translate";
+import {useApi, useCall} from "@polkadot/react-hooks";
+import type { DeriveStakingElected } from '@polkadot/api-derive/types';
+import FormatBalance from '@polkadot/app-generic-asset/FormatBalance';
+import {poolRegistry} from "@polkadot/app-staking/Overview/Address/poolRegistry";
+import {STAKING_ASSET_NAME} from "@polkadot/app-generic-asset/assetsRegistry";
+import Available from "@polkadot/app-generic-asset/Available";
+import BN from "bn.js";
+import {AssetId, Balance, Codec} from "@cennznet/types";
+import { SubmittableExtrinsic } from '@polkadot/api/promise/types';
 
 interface Props extends BareProps {
   isVisible: boolean;
 }
 
-export default function Actions ({ className, isVisible }: Props): React.ReactElement<Props> {
-  return (
-    <div className={`${className} ${!isVisible && 'staking--hidden'}`}>
 
-    </div>
-  );
+export default function Actions ({ className, isVisible }: Props): React.ReactElement<Props> {
+    const { api } = useApi();
+    const electedInfo = useCall<DeriveStakingElected>(api.derive.staking.electedInfo);
+
+    const chainInfo = useCall<string>(api.rpc.system.chain, []);
+    const [stashAccountId, setStashAccountId] = useState<string | null | undefined>();
+    const [assetBalance, setAssetBalance] = useState<BN>(new BN(0));
+    const stakingAssetId = useCall<AssetId>(api.query.genericAsset.stakingAssetId as any, []);
+    const [extrinsic, setExtrinsic] = useState<SubmittableExtrinsic | null>(null);
+    const [rewardDestinationId, setRewardDestinationId] = useState<string | null | undefined>();
+    const [isCreateOpen, setIsCreateOpen] = useState(false);
+    const [accountIdVec, setAccountIdVec] = useState<string[]>([]);
+    const chain: string | undefined = chainInfo ? chainInfo.toString() : undefined;
+    const [ isValid, setIsValid] = useState<boolean>(false);
+    const [hasAvailable, setHasAvailable] = useState(true);
+    const [amount, setAmount] = useState<BN | undefined>(new BN(0));
+    const nominate = (): void => setIsCreateOpen(!isCreateOpen);
+    useMemo((): void => {
+        if (stakingAssetId && stashAccountId) {
+            api.query.genericAsset.freeBalance(stakingAssetId, stashAccountId!).then(
+                (balance: Codec) => setAssetBalance((balance as Balance).toBn())
+            );
+        }
+    }, [stakingAssetId]);
+    useEffect((): void => {
+        if (accountIdVec.length === 0 || stashAccountId === null || rewardDestinationId === null || amount?.isZero() || amount?.gte(assetBalance)) {
+            setIsValid(false);
+        } else {
+            setIsValid(true);
+        }
+        if (amount !== undefined && !amount!.isZero()) {
+            setHasAvailable(amount.lte(assetBalance));
+        } else {
+            setHasAvailable(true);
+        }
+    }, [stashAccountId, rewardDestinationId, amount, accountIdVec]);
+
+    // create an extrinsic if we have correct values
+    useEffect((): void => {
+        if (isValid) {
+            const txs = [];
+            const bondTx = api.tx.staking.bond(stashAccountId as string, amount as BN, { Account: rewardDestinationId});
+            const nominateTx = api.tx.staking.nominate(accountIdVec);
+            txs.push(bondTx);
+            txs.push(nominateTx);
+            setExtrinsic(api.tx.utility.batch(txs));
+        }
+    }, [isValid]);
+
+    const _validatorSelected = (element: any): void => {
+        const accountSelected: string = element.currentTarget.value;
+        const accounts: string[] = accountIdVec;
+        if (element.target.checked && accountSelected) {
+            accounts.push(accountSelected);
+        } else if (!element.target.checked && accounts.includes(accountSelected)) {
+            const index = accounts.indexOf(accountSelected);
+            if (index > -1) {
+                accounts.splice(index, 1);
+            }
+        }
+        setAccountIdVec(accounts);
+        if (accountIdVec.length === 0 || stashAccountId === null || rewardDestinationId === null || amount?.isZero() || amount?.gte(assetBalance)) {
+            setIsValid(false);
+        } else {
+            setIsValid(true);
+        }
+    }
+    const { t } = useTranslation();
+    const transferrable = <span className='label'>{t('transferrable')}</span>;
+    const notEnoughTransferrable = <span style={{ color: "#9f3a38" }}>{t('not enough to stake')}</span>;
+
+      return (
+          <div>
+            <div className={`${className} ${!isVisible && 'staking--hidden'}`} style={{fontSize:'24px', color:'black'}}>
+              Stake <b>CENNZ</b> and nominate the best validators to earn <b>Cpay</b> rewards
+            </div>
+            <Button
+                  style={{marginTop:'1%', backgroundColor: '#f19135'}}
+                  label={t('Know the risks')}
+                  icon='exclamation'
+                  onClick={() => { window.open(`https://medium.com/centrality/the-cennznet-journey-part-2-public-staking-a994daa65856#c888`,"_blank" )}}
+                  isPrimary
+            />
+            <div className='extrinsics--Selection' style={{marginTop:'2%', width:'50%', borderRadius: '35px', padding: '20px', border: '2px solid #D0D0D0', background:'white'}}>
+                <div className='menuActive'>
+                    <Icon name={'users'} size='huge' color={'black'}/>
+                    <span>{'new nominator'}</span>
+                </div>
+                <InputAddress
+                    label={t('Stash')}
+                    help={t('Choose an account to stake CENNZ with')}
+                    labelExtra={<Available label={transferrable} params={stashAccountId} />}
+                    onChange={setStashAccountId}
+                    type='account'
+                />
+                <InputAddress
+                    label={t('Reward to')}
+                    help={t('Choose an account where Cpay rewards will be paid')}
+                    labelExtra={<Available label={transferrable} params={rewardDestinationId} />}
+                    onChange={setRewardDestinationId}
+                    type='allPlus'
+                />
+                <InputBalance
+                    help={t('The amount of CENNZ to put at stake')}
+                    label={t('Stake')}
+                    labelExtra={!hasAvailable && notEnoughTransferrable}
+                    onChange={setAmount}
+                />
+                <div>
+                    Select validators to nominate
+                        <Table>
+                            <Table.Body>
+                                {electedInfo?.info.map(({ accountId, exposure }): React.ReactNode => (
+                                    <tr className={className} key={accountId.toString()}>
+                                        <td className='address'>
+                                            <AddressSmall value={accountId.toString()} />
+                                        </td>
+                                        <td className='address'>
+                                            {chain? poolRegistry[chain][accountId.toString()]: 'CENTRALITY'}
+                                        </td>
+                                        <td style={{width:'15%', whiteSpace:'nowrap'}}>
+                                            {exposure.total?.toBn()?.gtn(0) && (
+                                                <FormatBalance value={exposure.total} symbol={STAKING_ASSET_NAME}/>)}
+                                        </td>
+                                        <td>
+                                            <input
+                                                type={"checkbox"}
+                                                value={accountId.toString()}
+                                                onClick={_validatorSelected}
+                                            />
+                                        </td>
+                                    </tr>
+                                ))}
+                            </Table.Body>
+                        </Table>
+                    <div style={{marginLeft:'45%'}}>
+                        <TxButton
+                            accountId={stashAccountId}
+                            extrinsic={extrinsic}
+                            icon='check'
+                            isDisabled={!isValid}
+                            isPrimary
+                            label={t('nominate')}
+                            onClick={nominate}
+                        />
+                    </div>
+                </div>
+
+            </div>
+          </div>
+
+      );
 }

--- a/packages/app-staking/src/OnboardNominators/index.tsx
+++ b/packages/app-staking/src/OnboardNominators/index.tsx
@@ -179,6 +179,13 @@ function OnboardNominators ({ className, isVisible }: Props): React.ReactElement
                   </div>
                   <Table>
                     <Table.Body>
+                      <tr>
+                        <th>{t('Validator')}</th>
+                        <th>{t('Pool')}</th>
+                        <th>{t('Commission')}</th>
+                        <th>{t('Total Staked')}</th>
+                        <th></th>
+                      </tr>
                       {electedInfo?.info.map(({ accountId, exposure, validatorPrefs }): React.ReactNode => (
                         <tr className={className} key={accountId.toString()}>
                           <td className='address'>
@@ -226,7 +233,7 @@ export default styled(OnboardNominators)`
     font-size: 22px;
     margin-top: 3rem;
     margin-left: 1.2rem;
-    color:${colors.N1000};
+    color: ${colors.N1000};
   }
 
   .ui.primary.button.know-risk {
@@ -236,12 +243,12 @@ export default styled(OnboardNominators)`
   }
 
   .nominator--Selection {
+    min-width: 663px;
     margin-top: 1.5rem;
-     width: 50%;
-     border-radius: 35px;
-     padding: 20px;
-     border: 2px solid ${colors.lightGrey};
-     background: ${colors.N0};
+    width: 50%;
+    border-radius: 35px;
+    padding: 20px;
+    background: ${colors.N0};
   }
 
   .menuActive {
@@ -258,6 +265,13 @@ export default styled(OnboardNominators)`
 
   .validator-info {
     margin-top: 3rem;
+    padding-left: 2rem;
+    th {
+      background: ${colors.N0};
+      color: ${colors.matterhorn};
+      text-align: left;
+      font-size: 15px;
+    }
     .label {
       margin-left: 1.5rem;
       font-size: 18px;
@@ -271,6 +285,7 @@ export default styled(OnboardNominators)`
       width:  20px;
       height: 20px;
       border:2px solid #555;
+      cursor: pointer;
     }
   }
 `;

--- a/packages/app-staking/src/OnboardNominators/index.tsx
+++ b/packages/app-staking/src/OnboardNominators/index.tsx
@@ -36,7 +36,7 @@ interface Props extends BareProps {
 function OnboardNominators ({ className, isVisible }: Props): React.ReactElement<Props> {
     const { api } = useApi();
     const electedInfo = useCall<DeriveStakingElected>(api.derive.staking.electedInfo);
-
+    const minimumBond = useCall<Balance>(api.query.staking.minimumBond);
     const chainInfo = useCall<string>(api.rpc.system.chain, []);
     const [stashAccountId, setStashAccountId] = useState<string | null | undefined>();
     const [assetBalance, setAssetBalance] = useState<BN>(new BN(0));
@@ -116,7 +116,14 @@ function OnboardNominators ({ className, isVisible }: Props): React.ReactElement
       setIsAccountImportModalOpen(!isAccountImportModalOpen);
     const onStatusChange = (): void =>
       setAccountCheckingModalOpen(!isAccountCheckingModalOpen);
-    const notEnoughToStake = <span style={{ color: `${colors.red}` }}>{hasAccounts ? t('not enough to stake'): t('no account exist')}</span>;
+    const notEnoughToStake =
+      <span style={{ color: `${colors.red}` }}>
+        { hasAccounts && minimumBond ?
+          (amount as BN)?.lt(minimumBond as BN)?
+            t(`Minimum bond amount - ${minimumBond.divn(10000)}`) :
+            t('Not enough to stake')
+          : t('No account exist')}
+      </span>;
 
     return (
           <div className={className}>
@@ -247,7 +254,7 @@ export default styled(OnboardNominators)`
     margin-top: 1.5rem;
     width: 50%;
     border-radius: 35px;
-    padding: 20px;
+    padding: 20px 3.8rem 20px 20px;
     background: ${colors.N0};
   }
 
@@ -273,13 +280,12 @@ export default styled(OnboardNominators)`
       font-size: 15px;
     }
     .label {
-      margin-left: 1.5rem;
       font-size: 18px;
       font-weight: 100;
       margin-bottom: 2rem;
     }
     .submitTx {
-      margin-left: 45%;
+      margin-left: 40%;
     }
     .checkbox {
       width:  20px;

--- a/packages/app-staking/src/OnboardNominators/index.tsx
+++ b/packages/app-staking/src/OnboardNominators/index.tsx
@@ -157,7 +157,6 @@ function OnboardNominators ({ className, isVisible }: Props): React.ReactElement
                 <InputAddress
                     label={t('Stash')}
                     help={t('Choose an account to stake CENNZ with')}
-                    // labelExtra={<Available label={available} params={stashAccountId} />}
                     labelExtra={<FormatBalance label={available} value={assetBalance} symbol={STAKING_ASSET_NAME}/>}
                     onChange={setStashAccountId}
                     type='account'
@@ -165,7 +164,6 @@ function OnboardNominators ({ className, isVisible }: Props): React.ReactElement
                 <InputAddress
                     label={t('Reward to')}
                     help={t('Choose an account where Cpay rewards will be paid')}
-                    // labelExtra={<Available label={transferrable} params={rewardDestinationId} />}
                     onChange={setRewardDestinationId}
                     type='allPlus'
                 />

--- a/packages/app-staking/src/index.tsx
+++ b/packages/app-staking/src/index.tsx
@@ -8,7 +8,7 @@ import { useLocation } from 'react-router-dom';
 import { Route, Switch } from 'react-router';
 import Tabs from '@polkadot/react-components/Tabs';
 import { useAccounts, useCall, useApi, useFavorites, useStashIds } from '@polkadot/react-hooks';
-import Actions from './Actions';
+import OnboardNominators from './OnboardNominators';
 import Overview from './Overview';
 import Summary from './Overview/Summary';
 import useSortedTargets from './useSortedTargets';
@@ -61,7 +61,7 @@ export default function ToolboxApp ({ basePath }: Props): React.ReactElement<Pro
         },
         {
             name: 'manage',
-            text: t('new stake')
+            text: t('manage stake')
         },
     ], [t]);
 
@@ -101,8 +101,8 @@ export default function ToolboxApp ({ basePath }: Props): React.ReactElement<Pro
                         toggleFavorite={toggleFavorite}
                     />
                 </Route>
-                <Route path={`${basePath}/stake`} component={Actions} />
-                <Route path={`${basePath}/manage`} component={Actions} />
+                <Route path={`${basePath}/stake`} component={OnboardNominators} />
+                <Route path={`${basePath}/manage`} component={OnboardNominators} />
                 <Route><Overview
                     favorites={favorites}
                     hasQueries={hasQueries}

--- a/packages/app-staking/src/index.tsx
+++ b/packages/app-staking/src/index.tsx
@@ -102,7 +102,16 @@ export default function ToolboxApp ({ basePath }: Props): React.ReactElement<Pro
                     />
                 </Route>
                 <Route path={`${basePath}/stake`} component={OnboardNominators} />
-                <Route path={`${basePath}/manage`} component={OnboardNominators} />
+                <Route path={`${basePath}/manage`}>
+                  <Overview
+                    favorites={favorites}
+                    hasQueries={hasQueries}
+                    next={next}
+                    stakingOverview={stakingOverview}
+                    targets={targets}
+                    toggleFavorite={toggleFavorite}
+                  />
+                </Route>
                 <Route><Overview
                     favorites={favorites}
                     hasQueries={hasQueries}

--- a/packages/app-staking/src/index.tsx
+++ b/packages/app-staking/src/index.tsx
@@ -53,11 +53,15 @@ export default function ToolboxApp ({ basePath }: Props): React.ReactElement<Pro
         {
             isRoot: true,
             name: 'overview',
-            text: t('Overview')
+            text: t('overview')
         },
         {
-            name: 'actions',
-            text: t('Actions')
+            name: 'stake',
+            text: t('new stake')
+        },
+        {
+            name: 'manage',
+            text: t('new stake')
         },
     ], [t]);
 
@@ -74,13 +78,18 @@ export default function ToolboxApp ({ basePath }: Props): React.ReactElement<Pro
                     items={items}
                 />
             </header>
-            <Summary
-                isVisible={pathname === basePath}
-                next={next}
-                nominators={targets.nominators}
-                stakingOverview={stakingOverview}
-                rewards={`${rewards}`}
-            />
+            {pathname === `/staking` ?
+                (
+                    <Summary
+                        isVisible={pathname === basePath}
+                        next={next}
+                        nominators={targets.nominators}
+                        stakingOverview={stakingOverview}
+                        rewards={`${rewards}`}
+                    />
+                ):
+                null
+            }
             <Switch>
                 <Route path={`${basePath}/overview`}>
                     <Overview
@@ -92,7 +101,8 @@ export default function ToolboxApp ({ basePath }: Props): React.ReactElement<Pro
                         toggleFavorite={toggleFavorite}
                     />
                 </Route>
-                <Route path={`${basePath}/actions`} component={Actions} />
+                <Route path={`${basePath}/stake`} component={Actions} />
+                <Route path={`${basePath}/manage`} component={Actions} />
                 <Route><Overview
                     favorites={favorites}
                     hasQueries={hasQueries}

--- a/packages/app-staking/src/md/basic.md
+++ b/packages/app-staking/src/md/basic.md
@@ -1,20 +1,20 @@
 # Nominators
 
-Nominators have a responsibility to elect the most trustworthy validators to secure the network.
-To become a nominator you must stake the minimum required CENNZ tokens and vote for your preferred validators.
+Nominators have a responsibility to elect the most trustworthy validators to secure the network.  
+To become a nominator you must stake the minimum required CENNZ tokens and vote for your preferred validators.  
 
 Important things to note are:
-- Nominators share proportionally in Cpay rewards according to their contributed stake, if their validator(s) are elected and participate correctly.
-- If elected validators behave maliciously, nominators' stake will be slashed proportionally alongside the validator's.
+- Nominators share proportionally in Cpay rewards according to their contributed stake, if their validator(s) are elected and participate correctly.  
+- If elected validators behave maliciously, nominators' stake will be slashed proportionally alongside the validator's.  
 
 e.g. if a nominator contributes 30% of a validators total stake they may receive 30% of the reward. Conversely, nominator will share 30% of slashes (confiscation of CENNZ) if the validator misbehaves.
 
 - Nominators are encouraged and incentivized to stay aware of validator activity and change their nominations if required.
 
 # Validators
-Operate CENNZnet nodes to make blocks and participate in consensus protocols securing the network.
+Operate CENNZnet nodes to make blocks and participate in consensus protocols securing the network.  
 
-- Validators have a right to set a % commission rate reward which will be deducted before sharing with nominators.
+- Validators have a right to set a % commission rate reward which will be deducted before sharing with nominators.  
 - Validators earn Cpay rewards but can incur slash if they misbehave in the protocol.
 - Validators with the highest total stake are elected
 

--- a/packages/app-staking/src/md/basic.md
+++ b/packages/app-staking/src/md/basic.md
@@ -1,4 +1,5 @@
 # Nominators
+
 Nominators have a responsibility to elect the most trustworthy validators to secure the network.
 To become a nominator you must stake CENNZ tokens and then vote for your preferred validators.
 Nominators will share proportionally in Cpay rewards if their validator(s) are elected and
@@ -7,9 +8,13 @@ If their chosen validators behave maliciously the nominator's stake will be slas
 proportionally along with the validators.
 e.g. if a nominator contributes 30% of a validators total stake they may receive 30% of the reward.
 Conversely, nominator will share 30% of slashes (confiscation of CENNZ) if the validator misbehaves.
+
 Nominators are encouraged and incentivized to stay aware of validator activity and change their nominations if required.
+
 # Validators
+
 Accounts linked with CENNZnet nodes, make blocks and participate in consensus protocols to secure the network.
 Validators have a right to set a commission rate reward which will be deducted before sharing with nominators.
 Validators earn Cpay rewards but can incur slash if they misbehave in the protocol.
+
 for more information see the [official blog post](https://medium.com/centrality/the-cennznet-journey-part-2-public-staking-a994daa65856)

--- a/packages/app-staking/src/md/basic.md
+++ b/packages/app-staking/src/md/basic.md
@@ -1,20 +1,20 @@
 # Nominators
 
-Nominators have a responsibility to elect the most trustworthy validators to secure the network.  
-To become a nominator you must stake the minimum required CENNZ tokens and vote for your preferred validators.  
+Nominators have a responsibility to elect the most trustworthy validators to secure the network.
+To become a nominator you must stake the minimum required CENNZ tokens and vote for your preferred validators.
 
 Important things to note are:
-- Nominators share proportionally in Cpay rewards acoording to their contributed stake, if their validator(s) are elected and participate correctly.  
-- If elected validators behave maliciously, nominators' stake will be slashed proportionally alongside the validator's.  
+- Nominators share proportionally in Cpay rewards according to their contributed stake, if their validator(s) are elected and participate correctly.
+- If elected validators behave maliciously, nominators' stake will be slashed proportionally alongside the validator's.
 
 e.g. if a nominator contributes 30% of a validators total stake they may receive 30% of the reward. Conversely, nominator will share 30% of slashes (confiscation of CENNZ) if the validator misbehaves.
 
 - Nominators are encouraged and incentivized to stay aware of validator activity and change their nominations if required.
 
 # Validators
-Operate CENNZnet nodes to make blocks and participate in consensus protocols securing the network.  
+Operate CENNZnet nodes to make blocks and participate in consensus protocols securing the network.
 
-- Validators have a right to set a % commission rate reward which will be deducted before sharing with nominators.  
+- Validators have a right to set a % commission rate reward which will be deducted before sharing with nominators.
 - Validators earn Cpay rewards but can incur slash if they misbehave in the protocol.
 - Validators with the highest total stake are elected
 

--- a/packages/app-staking/src/md/basic.md
+++ b/packages/app-staking/src/md/basic.md
@@ -1,32 +1,15 @@
-# Staking
-
-Welcome to the staking module. Here you can see an overview of all the validators on the network and participate in the network as either a validator (running a node that helps secure the network), or a nominator (adding funds to help secure the network).
-
-Validators and nominators earn rewards at the end of an era: the rewards are split between the validators and nominators for that validator, in proportion to the amount bonded by each individual.
-
-# Bonding
-
-Bonding funds is the first step that either a validator or nominator performs. It locks up a portion of funds that is used to secure the network. These funds are placed at risk, i.e. you can be slashed and lose a portion if the validator node misbehaves. Validators and nominators share both rewards and the slashing effects. Choosing a well behaving validator to nominate is crucial.
-
-For bonding (with an intention to either validate or nominate), you need to have 2 accounts -
-
-- **Stash** This is the primary account that holds the funds and has a portion bonded for participation;
-- **Controller** This is used to control the operation of the validator or nominator, switching between validating, nominating and idle; (It only needs enough funds to send transactions when actions are taken)
-
-To bond, you select the stash account, bond from it and designate a controller. Additionally you can select the amount of funds to bond and set your payout preferences.
-
-# Nominating
-
-Nomination (using the controller account as set as part of the bonding) is a process of selecting a number of validators (or potential validators) that you deem trustworthy. Once the validators are selected, the bonded value is assigned to participate in the network security.
-
-At any point you could stop nominating (using the controller) or top up the funds bonded (from the stash).
-
-# Validating
-
-Validators run nodes that author blocks. The primary requirement here is the ability to run a node that is available 24/7 and is well-connected to the network.
-
-In addition to the stash and controller account described above, a validator has to indicate an additional account called `Session key` -
-
-- **Session** The seed of this account should be passed to the node using the `--key` parameter. The session account does not need to have funds as it does not need to send any transaction. The best practice is to create a dedicated account to be used as session account. Although a single account can theoretically be used as both session and controller, it is not recommended to do so. Having a dedicated session account would prevent the theft of funds should the validator node be compromised and the `--key` leaked.
-
-As with the nomination operations, you can stop validation at any time using the controller. (Be it for maintenance, upgrades, or any other reason)
+# Nominators
+Nominators have a responsibility to elect the most trustworthy validators to secure the network.
+To become a nominator you must stake CENNZ tokens and then vote for your preferred validators.
+Nominators will share proportionally in Cpay rewards if their validator(s) are elected and
+participates correctly.
+If their chosen validators behave maliciously the nominator's stake will be slashed
+proportionally along with the validators.
+e.g. if a nominator contributes 30% of a validators total stake they may receive 30% of the reward.
+Conversely, nominator will share 30% of slashes (confiscation of CENNZ) if the validator misbehaves.
+Nominators are encouraged and incentivized to stay aware of validator activity and change their nominations if required.
+# Validators
+Accounts linked with CENNZnet nodes, make blocks and participate in consensus protocols to secure the network.
+Validators have a right to set a commission rate reward which will be deducted before sharing with nominators.
+Validators earn Cpay rewards but can incur slash if they misbehave in the protocol.
+for more information see the [official blog post](https://medium.com/centrality/the-cennznet-journey-part-2-public-staking-a994daa65856)

--- a/packages/app-staking/src/md/basic.md
+++ b/packages/app-staking/src/md/basic.md
@@ -1,20 +1,21 @@
 # Nominators
 
-Nominators have a responsibility to elect the most trustworthy validators to secure the network.
-To become a nominator you must stake CENNZ tokens and then vote for your preferred validators.
-Nominators will share proportionally in Cpay rewards if their validator(s) are elected and
-participates correctly.
-If their chosen validators behave maliciously the nominator's stake will be slashed
-proportionally along with the validators.
-e.g. if a nominator contributes 30% of a validators total stake they may receive 30% of the reward.
-Conversely, nominator will share 30% of slashes (confiscation of CENNZ) if the validator misbehaves.
+Nominators have a responsibility to elect the most trustworthy validators to secure the network.  
+To become a nominator you must stake the minimum required CENNZ tokens and vote for your preferred validators.  
 
-Nominators are encouraged and incentivized to stay aware of validator activity and change their nominations if required.
+Important things to note are:
+- Nominators share proportionally in Cpay rewards acoording to their contributed stake, if their validator(s) are elected and participate correctly.  
+- If elected validators behave maliciously, nominators' stake will be slashed proportionally alongside the validator's.  
+
+e.g. if a nominator contributes 30% of a validators total stake they may receive 30% of the reward. Conversely, nominator will share 30% of slashes (confiscation of CENNZ) if the validator misbehaves.
+
+- Nominators are encouraged and incentivized to stay aware of validator activity and change their nominations if required.
 
 # Validators
+Operate CENNZnet nodes to make blocks and participate in consensus protocols securing the network.  
 
-Accounts linked with CENNZnet nodes, make blocks and participate in consensus protocols to secure the network.
-Validators have a right to set a commission rate reward which will be deducted before sharing with nominators.
-Validators earn Cpay rewards but can incur slash if they misbehave in the protocol.
+- Validators have a right to set a % commission rate reward which will be deducted before sharing with nominators.  
+- Validators earn Cpay rewards but can incur slash if they misbehave in the protocol.
+- Validators with the highest total stake are elected
 
 for more information see the [official blog post](https://medium.com/centrality/the-cennznet-journey-part-2-public-staking-a994daa65856)

--- a/packages/react-components/src/HelpOverlay.tsx
+++ b/packages/react-components/src/HelpOverlay.tsx
@@ -12,12 +12,18 @@ import Icon from './Icon';
 
 interface Props extends BareProps {
   md: string;
+  initialVisibility?: boolean;
 }
 
-function HelpOverlay ({ className, md }: Props): React.ReactElement<Props> {
+function HelpOverlay ({ className, md, initialVisibility, closeHelp }: Props): React.ReactElement<Props> {
   const [isVisible, setIsVisible] = useState(false);
 
-  const _toggleVisible = (): void => setIsVisible(!isVisible);
+  const _toggleVisible = (): void => {
+    setIsVisible(!isVisible);
+    if (initialVisibility) {
+      closeHelp(false);
+    }
+  }
 
   return (
     <div className={className}>
@@ -27,7 +33,7 @@ function HelpOverlay ({ className, md }: Props): React.ReactElement<Props> {
           onClick={_toggleVisible}
         />
       </div>
-      <div className={`help-slideout ${isVisible ? 'open' : 'closed'}`}>
+      <div className={`help-slideout ${isVisible || initialVisibility ? 'open' : 'closed'}`}>
         <div className='help-button'>
           <Icon
             name='close'

--- a/packages/react-components/src/HelpOverlay.tsx
+++ b/packages/react-components/src/HelpOverlay.tsx
@@ -12,16 +12,18 @@ import Icon from './Icon';
 
 interface Props extends BareProps {
   md: string;
-  initialVisibility?: boolean;
+  openHelpDailog?: boolean;
+  closeHelp?: (param: boolean) => void;
 }
 
-function HelpOverlay ({ className, md, initialVisibility, closeHelp }: Props): React.ReactElement<Props> {
+function HelpOverlay ({ className, md, openHelpDailog, closeHelp }: Props): React.ReactElement<Props> {
   const [isVisible, setIsVisible] = useState(false);
 
   const _toggleVisible = (): void => {
-    setIsVisible(!isVisible);
-    if (initialVisibility) {
+    if (openHelpDailog && closeHelp) {
       closeHelp(false);
+    } else {
+      setIsVisible(!isVisible);
     }
   }
 
@@ -33,7 +35,7 @@ function HelpOverlay ({ className, md, initialVisibility, closeHelp }: Props): R
           onClick={_toggleVisible}
         />
       </div>
-      <div className={`help-slideout ${isVisible || initialVisibility ? 'open' : 'closed'}`}>
+      <div className={`help-slideout ${isVisible || openHelpDailog ? 'open' : 'closed'}`}>
         <div className='help-button'>
           <Icon
             name='close'

--- a/styled-theming/themes/dark/colors.ts
+++ b/styled-theming/themes/dark/colors.ts
@@ -94,6 +94,10 @@ export const textHover = N200;
 export const link = B500;
 export const linkHover = B600;
 export const popUpBackground = '#1B1C1D';
+
+/* highlighted buttons, orange */
+export const highlightedOrange = '#f19135';
+export const lightGrey = '#D0D0D0';
 /*
  * NOTICE: this file only contains basic color defination of basic elements like border,
  * text, link, etc.

--- a/styled-theming/themes/dark/colors.ts
+++ b/styled-theming/themes/dark/colors.ts
@@ -97,7 +97,7 @@ export const popUpBackground = '#1B1C1D';
 
 /* highlighted buttons, orange */
 export const highlightedOrange = '#f19135';
-export const lightGrey = '#D0D0D0';
+export const matterhorn = '#4e4e4e';
 /*
  * NOTICE: this file only contains basic color defination of basic elements like border,
  * text, link, etc.

--- a/styled-theming/themes/dark/colors.ts
+++ b/styled-theming/themes/dark/colors.ts
@@ -98,6 +98,7 @@ export const popUpBackground = '#1B1C1D';
 /* highlighted buttons, orange */
 export const highlightedOrange = '#f19135';
 export const matterhorn = '#4e4e4e';
+export const lightBrown = '#f3e8d4';
 /*
  * NOTICE: this file only contains basic color defination of basic elements like border,
  * text, link, etc.


### PR DESCRIPTION
Created view to onboard new nominators.

1. If there are no accounts created, then it will open a pop-up to let user create/import account before landing on this page. However, user can click on later and that would display error message on the page - no account exist
2. Bond and nominate will be executed as one extrinsic
3. Click on 'Know the risk' will open help dialog
4. If the bonded amount is greater than account's CENNZ balance - error message would be displayed - not enough to stake
5. Used styled components and added two colours in styled-theming/themes/dark/colors.ts and used all the colours from here.