### PR TITLE
Add more statuses for staking nominations

### DIFF
--- a/packages/app-staking/src/MyStake/index.tsx
+++ b/packages/app-staking/src/MyStake/index.tsx
@@ -9,7 +9,7 @@ import { useApi, useCacheKey } from '@polkadot/react-hooks';
 import { BigNumber } from "bignumber.js";
 import BN from 'bn.js';
 
-import { findStakedAccounts, StakePair, STORE_STAKES } from './utils';
+import { findStakedAccounts, NominationState, StakePair, STORE_STAKES } from './utils';
 import { Api } from '@cennznet/api';
 import StakeInfo from './StakeInfo';
 import { colors } from '../../../../styled-theming';
@@ -31,8 +31,8 @@ export interface Nomination {
   stakeShare: BigNumber;
   // the raw stake contributed to this nomination
   stakeRaw: BigNumber;
-  // whether the nominated validator is elected this era or not
-  elected: boolean;
+  // the state of the nomination this era
+  state: NominationState;
 }
 
 interface Props {


### PR DESCRIPTION
Changes:
- adds statuses for "reallocated" and "oversubscribed" situations
- display raw stake alongside stake share

ignore reward, Nikau's messed up because stake share is so small that reward is near `0`

<img width="1122" alt="Screen Shot 2021-03-22 at 11 46 59" src="https://user-images.githubusercontent.com/5133901/111923642-0468b380-8b05-11eb-9b11-a061ad11057c.png">
