### PR TITLE
Fix BigNumber transfers

### DIFF
--- a/packages/react-components/src/InputNumber.tsx
+++ b/packages/react-components/src/InputNumber.tsx
@@ -3,7 +3,6 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import BN from 'bn.js';
-import BigNumber from 'bignumber.js';
 import React, { useEffect, useState } from 'react';
 
 import { decimalToFixedWidth } from '@polkadot/react-components/util';

--- a/packages/react-components/src/InputNumber.tsx
+++ b/packages/react-components/src/InputNumber.tsx
@@ -3,6 +3,7 @@
 // of the Apache-2.0 license. See the LICENSE file for details.
 
 import BN from 'bn.js';
+import BigNumber from 'bignumber.js';
 import React, { useEffect, useState } from 'react';
 
 import { decimalToFixedWidth } from '@polkadot/react-components/util';
@@ -108,12 +109,11 @@ function getValuesFromString (value: string, props: Props): [string, BN, boolean
   // sanitize the user input value, keeping digits and decimal point only.
   const valueSanitized = value.replace(/[^\d|\.]/g, '');
   const valueFormatted = formatInput(valueSanitized);
-  const valueBn = new BN(
-    decimalToFixedWidth({
-      value: valueSanitized,
-      fixedPoint: props.decimals || formatBalance.getDefaults().decimals,
-    })
-  );
+  let valueWei = decimalToFixedWidth({
+    value: valueSanitized,
+    fixedPoint: props.decimals || formatBalance.getDefaults().decimals,
+  });
+  let valueBn = new BN(valueWei);
 
   return [
     valueFormatted,

--- a/packages/react-components/src/util/toFormattedBalance.ts
+++ b/packages/react-components/src/util/toFormattedBalance.ts
@@ -92,7 +92,7 @@ const decimalToFixedWidth = (
     let [prefix, postfix = ''] = value.split('.');
     postfix = pad && postfix.length <= fixedPoint ? postfix.padEnd(fixedPoint, '0') : postfix.substring(0, fixedPoint);
     // this will also remove leading 0s for fixed width representation
-    return new BigNumber((+(prefix + postfix))).toString();
+    return new BigNumber(+(prefix + postfix)).toString();
 };
 
 export default toFormattedBalance;

--- a/packages/react-components/src/util/toFormattedBalance.ts
+++ b/packages/react-components/src/util/toFormattedBalance.ts
@@ -1,7 +1,13 @@
 import BN from 'bn.js';
+import BigNumber from 'bignumber.js';
 
 import { Balance } from '@polkadot/types/interfaces';
 import { formatBalance } from '@polkadot/util';
+
+// Using BigNumber to render strings of numbers
+// Force scientific notation off when numbers have <= 36 digits
+// This prevents BN.js parsing scientific notation and breaking e.g. '1.234e21'
+BigNumber.config({ EXPONENTIAL_AT: 36 });
 
 /**
  * To format balance with preference options
@@ -86,7 +92,7 @@ const decimalToFixedWidth = (
     let [prefix, postfix = ''] = value.split('.');
     postfix = pad && postfix.length <= fixedPoint ? postfix.padEnd(fixedPoint, '0') : postfix.substring(0, fixedPoint);
     // this will also remove leading 0s for fixed width representation
-    return (+(prefix + postfix)).toString();
+    return new BigNumber((+(prefix + postfix))).toString();
 };
 
 export default toFormattedBalance;

--- a/packages/react-components/test/toFormattedBalance.spec.ts
+++ b/packages/react-components/test/toFormattedBalance.spec.ts
@@ -206,5 +206,14 @@ describe('toFormattedBalance', () => {
       });
       expect(result).toEqual('0.1234');
     });
+
+    test('when value is a BN it is not scientific', () => {
+      const stubBalanceValue = '100000000.000000000000000000'; // 100 million, 18 dp
+      const result = decimalToFixedWidth({
+        value: stubBalanceValue,
+        fixedPoint: 18,
+      });
+      expect(result).toEqual('100000000000000000000000000');
+    });
   });
 });

--- a/packages/react-params/src/index.tsx
+++ b/packages/react-params/src/index.tsx
@@ -39,8 +39,20 @@ class Params extends React.PureComponent<Props, State> {
   public static getDerivedStateFromProps ({ isDisabled, params, values }: Props, prevState: State): Pick<State, never> | null {
     const isSame = JSON.stringify(prevState.params) === JSON.stringify(params);
 
+    // the params component has an asset ID in its context
+    // this could be inconsistent if there are multiple asset IDs in the component tree
+    // for now this is a best effort for most use cases.
+    let assetIdContext = undefined;
+    if (values && params) {
+      params.map(({ type }: ParamDef, index: number) => {
+        if (type.type?.includes('AssetId')) {
+          assetIdContext = values[index].value.toString();
+        }
+      });
+    }
+
     if (isDisabled || isSame) {
-      return null;
+      return { assetIdContext };
     }
 
     let values_ = params.reduce(
@@ -52,18 +64,6 @@ class Params extends React.PureComponent<Props, State> {
       ],
       []
     );
-
-    // the params component has an asset ID in it's context
-    // this could be inconsistent if there are multiple asset IDs in the component tree
-    // for now this is a best effort for most use cases.
-    let assetIdContext = undefined;
-    if (values && params) {
-      params.map(({ type }: ParamDef, index: number) => {
-        if (type.type?.includes('AssetId')) {
-          assetIdContext = values[index].value.toString();
-        }
-      });
-    }
 
     return {
       params,


### PR DESCRIPTION
fix 1) assetIdContext (decimal place info) would get lost if the component was disabled e.g. when `<Call.../>` is rendered
fix 2) prevent BNs from rendering with exponentation e.g. `1.23e22`